### PR TITLE
FIX - 리뷰 상세 보기 팝업 띄우면 닫기 버튼 동작 안함

### DIFF
--- a/views/mobile/reviews/_review.html.erb
+++ b/views/mobile/reviews/_review.html.erb
@@ -68,25 +68,13 @@ display_user_grade_icon = user_grade_icon_url.present? && @brand.brand_user_grad
       <% end %>
     <% end %>
     <div class="links">
-      <%
-      link_review_args = {
-        class: 'link-cover link-review'
-      }
-      if iframe?
-        link_review_args[:class] << ' link-fullscreen-popup'
-        concat content_tag(:a,
-          '',
-          class: link_review_args[:class],
-          data: {
-            url: mobile_review_path(review.id, popup: 1)
-          }
-        )
-      else
-        link_review_args[:"data-link-target"] = 'window'
-        link_review_args[:remote] = true
-        concat link_to('', mobile_review_path(review.id), link_review_args)
-      end
-      %>
+      <%= link_to(
+        '',
+        mobile_review_path(review.id),
+        class: 'link-cover link-review',
+        data: {link_target: 'window'},
+        remote: true
+      ) %>
     </div>
   </div>
 <% end %>


### PR DESCRIPTION
### 이유
- 리뷰 상세보기가 모달로 뜨고 있는데 이것은 삭제된 기능

### 수정 내용
- 리뷰 상세보기를 모달이 아닌 URL 이동으로 동작하도록 변경

https://app.asana.com/0/search/292519521653687/304550511413013