### PR TITLE
REMOVE - 불필요해진 “SNS형 팝업 사용 여부” 옵션 제거

### DIFF
--- a/views/pc/reviews/index/custom/_review.html.erb
+++ b/views/pc/reviews/index/custom/_review.html.erb
@@ -10,14 +10,8 @@ display_user_grade_icon = user_grade_icon_url.present? && @brand.brand_user_grad
     <% if review.images_count > 0 %>
       <%
         image = review.image(1)
-        if @brand.review_enable_gallery_popup
-          link_class = 'link-fullscreen-popup'
-          link_data = {url: photo_review_popup_review_path(review, photo_index: 1)}
-        else
-          link_class = 'link-image-zoom'
-          large_w, large_h = image.dimension(:large)
-          link_data = {url: image.url(:large), width: large_w, height: large_h}
-        end
+        link_class = 'link-fullscreen-popup'
+        link_data = {url: photo_review_popup_review_path(review, photo_index: 1)}
       %>
       <%= content_tag :a, data: link_data, class: link_class + " image" do %>
         <%= image_tag image.url(:thumbnail), class: 'review-image smooth', alt: review.title, width: 90, height: 90 %>


### PR DESCRIPTION
### 이유
- 모든 쇼핑몰이 true로 설정되어 있고, false로 바꿀 필요가 없음

### 제거 내용
- review_enable_gallery_popup storage 변수 및 사용하는 곳 모두 제거
- .link-image-zoom 관련 내용 제거 (`review_enable_gallery_popup`이 true인 경우에만 사용한다.)
- ImageZoom 관련 내용 제거 (`.link-image-zoom` 이 있을때만 사용한다.)

https://app.asana.com/0/75312375888163/308959848501467