### PR TITLE
FIX - facebook-like 버튼 주소를 absolute URL로 변경

### DIFF
--- a/assets/stylesheets/pc/app/reviews.css.scss
+++ b/assets/stylesheets/pc/app/reviews.css.scss
@@ -590,7 +590,7 @@ li.review {
 }
 
 .facebook_like {
-  background-image: image_url('facebook-like.png');
+  background-image: image_url('http://assets2.cre.ma/latte/assets/graychic-co-kr/facebook-like.png');
   background-repeat: no-repeat;
   background-size: auto;
   width: 15px;


### PR DESCRIPTION
### 설명
- 원래는 /latte/assets/graychic-co-kr/facebook-like.png 로 나와야 하지만 무슨 이유인지 나오지 않는다.
- 정상적으로 고치려면 근본 원인을 찾아야 하지만, 다음 Milestone에 Full Custom을 없앨 예정이므로 쉽게 고쳐둔다.

https://app.asana.com/0/6477513906633/387459762277340